### PR TITLE
refactor(view): Disable color picker for ludo menu

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/controller/ludo/LudoMenuController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/controller/ludo/LudoMenuController.java
@@ -1,5 +1,7 @@
 package edu.ntnu.idi.idatt.controller.ludo;
 
+import edu.ntnu.idi.idatt.factory.player.PlayerFactory;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +48,30 @@ public class LudoMenuController extends MenuController {
     menuView.setSelectedBoard(boardFactory.createBoard("Classic"));
     menuView.initialize("Ludo Game Menu", ALLOWED_PLAYER_TOKEN_TYPES, ALLOWED_PLAYER_COLORS,
         MIN_PLAYERS, MAX_PLAYERS);
+  }
+
+  /**
+   * Loads the players from the file at the given path and adds them to the main menu. Only allows
+   * ludo players to be imported.
+   *
+   * @param filePath The path to the file containing the players.
+   * @see PlayerFactory#createPlayersFromFile(String)
+   */
+  @Override
+  public void loadPlayersFromFile(String filePath) {
+    try {
+      List<Player> players = PlayerFactory.createPlayersFromFile(filePath);
+      for (Player player : players) {
+        if (player instanceof LudoPlayer) {
+          menuView.setPlayers(PlayerFactory.createPlayersFromFile(filePath));
+        } else {
+          throw new IOException("You can only import ludo players.");
+        }
+      }
+      menuView.showInfoAlert("Success", "Players loaded successfully");
+    } catch (IOException e) {
+      menuView.showErrorAlert("Error", "Could not load players");
+    }
   }
 
   @Override

--- a/src/main/java/edu/ntnu/idi/idatt/view/component/MenuPlayerRow.java
+++ b/src/main/java/edu/ntnu/idi/idatt/view/component/MenuPlayerRow.java
@@ -59,9 +59,10 @@ public class MenuPlayerRow extends HBox {
     playerButton = new Button();
     playerButton.setGraphic(playerToken);
     playerButton.getStyleClass().add("icon-only-button");
-    playerButton.setOnMouseClicked(
-        mouseEvent -> showPlayerColorPickerPopup(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
-
+    if (allowedPlayerTokenTypes.size() > 1) {
+      playerButton.setOnMouseClicked(mouseEvent ->
+          showPlayerColorPickerPopup(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
+    }
     nameTextField = new TextField(defaultName);
     deleteButton = new Button();
     deleteButton.setGraphic(new FontIcon("fas-trash"));
@@ -105,7 +106,7 @@ public class MenuPlayerRow extends HBox {
       });
       MenuItem initialColorMenuItem = colorMenuButton.getItems().stream()
           .filter(item -> ((Rectangle) item.getGraphic()).getFill().equals(getColor())).findFirst()
-          .orElse(colorMenuButton.getItems().get(0));
+          .orElse(colorMenuButton.getItems().getFirst());
       colorMenuButton.setText(initialColorMenuItem.getText());
       colorMenuButton.setGraphic(initialColorMenuItem.getGraphic());
       colorMenuButton.setOnAction(event -> {


### PR DESCRIPTION
The changes in this PR include disabling the color picker in the ludo game menu. This ensures the player colors always match the colors on the board. 

### Related issues
Closes #116 