### PR TITLE
chore(workflow): Upgrade actions artifact to v4

### DIFF
--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -32,7 +32,7 @@ jobs:
         run: mvn javadoc:javadoc
 
       - name: Upload JavaDoc artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./target/site/apidocs
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying JavaDoc to use the latest versions of the relevant actions.

### Related issues
#63 