### PR TITLE
chore(workflow): Set upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -32,7 +32,7 @@ jobs:
         run: mvn javadoc:javadoc
 
       - name: Upload JavaDoc artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./target/site/apidocs
 


### PR DESCRIPTION
This pull request sets the actions/upload-pages-artifact, used in the the workflow for deploying JavaDoc, to utilize the v3 release. 

### Related issues
#63 