### PR TITLE
feat(view): Add left panel title in ladder game board creator

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/view/laddergame/LadderGameBoardCreatorView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/view/laddergame/LadderGameBoardCreatorView.java
@@ -212,6 +212,7 @@ public class LadderGameBoardCreatorView extends BoardCreatorView {
 
     Text title = new Text("Drag components onto the board");
     title.getStyleClass().add("panel-title");
+    panel.getChildren().add(title);
 
     components.forEach((key, value) -> {
       VBox section = createComponentSection(key, value);


### PR DESCRIPTION
This PR includes a simple change: Adding a title to the left panel in the ladder game board creator view. 

### Related issues
Closes #137 