### PR TITLE
feat(view): Add menu dropshadows and adjust game selection card size

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/view/common/GameSelectionView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/view/common/GameSelectionView.java
@@ -76,7 +76,7 @@ public class GameSelectionView extends BorderPane implements ButtonClickSubject 
 
     HBox gameSelectionBox = new HBox();
     gameSelectionBox.setAlignment(Pos.CENTER);
-    gameSelectionBox.setSpacing(30);
+    gameSelectionBox.setSpacing(40);
     gameSelectionBox.setMinSize(0, 0);
     VBox.setVgrow(gameSelectionBox, Priority.ALWAYS);
 

--- a/src/main/resources/stylesheets/gameSelectionStyles.css
+++ b/src/main/resources/stylesheets/gameSelectionStyles.css
@@ -3,9 +3,10 @@
   -fx-padding: 20;
   -fx-spacing: 30;
   -fx-alignment: center;
-  -fx-max-height: 35em;
-  -fx-max-width: 55em;
+  -fx-max-height: 40em;
+  -fx-max-width: 60em;
   -fx-background-radius: 18;
+  -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 10, 0, 0, 0);
 }
 
 .title {
@@ -28,6 +29,8 @@
   -fx-alignment: center;
   -fx-effect: dropshadow(three-pass-box, black, 6, 0, 0, 0);
   -fx-cursor: hand;
+  -fx-max-height: 375px;
+  -fx-max-width: 325px;
 }
 
 .game-box:hover {

--- a/src/main/resources/stylesheets/menuStyles.css
+++ b/src/main/resources/stylesheets/menuStyles.css
@@ -7,6 +7,7 @@
   -fx-max-height: 35em;
   -fx-max-width: 55em;
   -fx-background-radius: 18;
+  -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 10, 0, 0, 0);
 }
 
 .menu-h-box {


### PR DESCRIPTION
This PR adds simple dropshadows to the content cards in both the game menus and the game selection view. It also adjusts the sizing of the game cards in the game selection view. 

### Related issues
Closes #73 